### PR TITLE
Automated dev setup using Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,3 @@
+tasks:
+  - init: gcc prashant.c
+    command: echo "Type a number:" && ./a.out


### PR DESCRIPTION
As requested in https://github.com/gitpod-io/gitpod/issues/951, this is an example how you can automate your setup with Gitpod.

To test it, simply prefix your GitHub URL with `gitpod.io/#`, e.g.:

https://gitpod.io/#https://github.com/jankeromnes/first-c-project

The configuration file I added will automatically compile your C code with `gcc`, and then run it in the Terminal, waiting for you to input a number.